### PR TITLE
Add support of the optional configuration testTasksFinalizedByReport

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ cucumberReports {
 
 #### Optional configuration
 
-`parallelTesting`: `true` or `false` determines if multiple tests were run in parallel
-
-`classifications`: A map with <String, String> pairs that are added to the HTML report, for example os name etc.
+- `parallelTesting`: `true` or `false` determines if multiple tests were run in parallel
+- `classifications`: A map with <String, String> pairs that are added to the HTML report, for example os name etc.
+- `testTasksFinalizedByReport`: `true` or `false` determines if the `generateCucumberReports` task finalizes the test tasks. `true` by default.
 
 ### License
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'maven-publish'
 }
 
-version = '0.0.10'
+version = '0.0.11'
 group = "com.github.spacialcircumstances"
 
 repositories {

--- a/src/main/groovy/com/github/spacialcircumstances/gradle/ReportsPlugin.groovy
+++ b/src/main/groovy/com/github/spacialcircumstances/gradle/ReportsPlugin.groovy
@@ -8,17 +8,20 @@ import org.gradle.api.tasks.testing.Test
 class ReportsPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        project.extensions.create('cucumberReports', ReportsPluginExtension)
+        def reportsPluginExtension = project.extensions.create('cucumberReports', ReportsPluginExtension)
         Task reportTask = project.task('generateCucumberReports', type: CreateReportFilesTask) {
             description = "Creates cucumber html reports"
             group = "Cucumber reports"
             projectName = project.displayName
         }
 
-        reportTask.onlyIf { ! project.hasProperty('skipReports') }
-
-        project.tasks.withType(Test) { Test test ->
-            test.finalizedBy(reportTask)
+        project.afterEvaluate {
+            if (project.extensions.cucumberReports.testTasksFinalizedByReport) {
+                project.tasks.withType(Test) { Test test ->
+                    test.finalizedBy(reportTask)
+                }
+            }
         }
+        reportTask.onlyIf { !project.hasProperty('skipReports') }
     }
 }

--- a/src/main/groovy/com/github/spacialcircumstances/gradle/ReportsPluginExtension.groovy
+++ b/src/main/groovy/com/github/spacialcircumstances/gradle/ReportsPluginExtension.groovy
@@ -1,8 +1,6 @@
 package com.github.spacialcircumstances.gradle
 
-import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.FileCollection
 
 class ReportsPluginExtension {
     File outputDir
@@ -10,5 +8,6 @@ class ReportsPluginExtension {
     ConfigurableFileCollection reports
     Boolean parallelTesting = false
     Boolean runWithJenkins = false
+    Boolean testTasksFinalizedByReport = true
     Map<String, String> classifications = new HashMap<>()
 }


### PR DESCRIPTION
I have a project dedicated for cucumber tests and I see them as integration/end 2 end/functional tests. In my setup, the cucumber code is in the main src folder and test is dedicated to unit tests of some logic of the cucumber tests.
In that context, the fact that the report task is added as "finalizedBy" of the test tasks blocked me to run only the unit tests by running "gradle test".
I suggest to add an optional flag to be able to switch off this feature.