### PR TITLE
Make the printed report path clickable

### DIFF
--- a/src/main/groovy/com/github/spacialcircumstances/gradle/CreateReportFilesTask.groovy
+++ b/src/main/groovy/com/github/spacialcircumstances/gradle/CreateReportFilesTask.groovy
@@ -54,7 +54,7 @@ class CreateReportFilesTask extends DefaultTask {
                 Reportable report = reportBuilder.generateReports()
                 if (report != null) {
                     println "Generated report in ${outputDirectory.absolutePath}/cucumber-html-reports/"
-                    println "Open ${outputDirectory.absolutePath}/cucumber-html-reports/overview-features.html to get an overview about the test results."
+                    println "Open file://${outputDirectory.absolutePath}/cucumber-html-reports/overview-features.html to get an overview about the test results."
                 } else {
                     throw new RuntimeException("Failed to generate test reports. Open ${outputDirectory.absolutePath}/cucumber-html-reports/overview-features.html to view the error page.")
                 }


### PR DESCRIPTION
Specifying the `file://` protocol would allow most terminals to auto-detect the path as a link and make it clickable.

Thank you for the plugin, very helpful.