### PR TITLE
Make the report path clickable

### DIFF
--- a/src/main/groovy/com/github/spacialcircumstances/gradle/CreateReportFilesTask.groovy
+++ b/src/main/groovy/com/github/spacialcircumstances/gradle/CreateReportFilesTask.groovy
@@ -66,7 +66,7 @@ class CreateReportFilesTask extends DefaultTask {
                     println "Generated report in ${outputDirectory.absolutePath}/cucumber-html-reports/"
                     println "Open file://${outputDirectory.absolutePath}/cucumber-html-reports/overview-features.html to get an overview about the test results."
                 } else {
-                    throw new RuntimeException("Failed to generate test reports. Open ${outputDirectory.absolutePath}/cucumber-html-reports/overview-features.html to view the error page.")
+                    throw new RuntimeException("Failed to generate test reports. Open file://${outputDirectory.absolutePath}/cucumber-html-reports/overview-features.html to view the error page.")
                 }
             } catch (Exception e) {
                 throw new TaskExecutionException(this, e)


### PR DESCRIPTION
Same as #7.

Just got hit by a "Failed to generate test reports" and noticed that the path is not clickable. I wonder how I missed this in #7 .

Anyways, thanks again for the great plugin.