### PR TITLE
updating the cucumber reporting version to 5.7.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'net.masterthought', name: 'cucumber-reporting', version: '5.5.4'
+    implementation group: 'net.masterthought', name: 'cucumber-reporting', version: '5.7.2'
     implementation localGroovy()
     testImplementation 'org.junit.jupiter:junit-jupiter:5.6.0'
 }


### PR DESCRIPTION
Updating the cucumber reporting version to 5.7.2 to fix the jsoup vulnerability present in cucumber reporting https://github.com/advisories/GHSA-gp7f-rwcx-9369